### PR TITLE
Slow new-comment polling to once per 10 seconds.

### DIFF
--- a/public/react.js
+++ b/public/react.js
@@ -105,6 +105,6 @@ var CommentBox = React.createClass({
 });
 
 React.render(
-	<CommentBox url="comments.json" />,
+	<CommentBox url="comments.json" pollInterval={10000} />,
 	document.getElementById('content')
 );


### PR DESCRIPTION
Poll interval was not set, so it would have been using 0 and trying to
poll every millisecond.
I set it to 10 seconds for now so it doesn't hammer people's network.
